### PR TITLE
add support for vim-prettier and coc-prettier

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const languages = [
         codemirrorMimeType: "text/melody-twig",
         extensions: [".melody.twig", ".html.twig", ".twig"],
         linguistLanguageId: 0,
-        vscodeLanguageIds: ["twig"]
+        vscodeLanguageIds: ["twig", "html.twig", "html.twig.js.js.css", "xml.twig"]
     }
 ];
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,13 @@ const languages = [
         codemirrorMimeType: "text/melody-twig",
         extensions: [".melody.twig", ".html.twig", ".twig"],
         linguistLanguageId: 0,
-        vscodeLanguageIds: ["twig", "html.twig", "html.twig.js.js.css", "xml.twig"]
-    }
+        vscodeLanguageIds: [
+            "twig",
+            "html.twig",
+            "html.twig.js.css",
+            "xml.twig",
+        ],
+    },
 ];
 
 function hasPragma(/* text */) {
@@ -38,8 +43,8 @@ const parsers = {
         astFormat: "melody",
         hasPragma,
         locStart,
-        locEnd
-    }
+        locEnd,
+    },
 };
 
 function canAttachComment(node) {
@@ -69,8 +74,8 @@ const printers = {
         printComment,
         canAttachComment,
         massageAstNode: clean,
-        willPrintOwnComments: () => true
-    }
+        willPrintOwnComments: () => true,
+    },
 };
 
 const options = {
@@ -80,53 +85,53 @@ const options = {
         array: true,
         default: [{ value: [] }],
         description:
-            "Provide additional plugins for Melody. Relative file path from the project root."
+            "Provide additional plugins for Melody. Relative file path from the project root.",
     },
     twigMultiTags: {
         type: "path",
         category: "Global",
         array: true,
         default: [{ value: [] }],
-        description: "Make custom Twig tags known to the parser."
+        description: "Make custom Twig tags known to the parser.",
     },
     twigSingleQuote: {
         type: "boolean",
         category: "Global",
         default: true,
-        description: "Use single quotes in Twig files?"
+        description: "Use single quotes in Twig files?",
     },
     twigAlwaysBreakObjects: {
         type: "boolean",
         category: "Global",
         default: true,
-        description: "Should objects always break in Twig files?"
+        description: "Should objects always break in Twig files?",
     },
     twigPrintWidth: {
         type: "int",
         category: "Global",
         default: 80,
-        description: "Print width for Twig files"
+        description: "Print width for Twig files",
     },
     twigFollowOfficialCodingStandards: {
         type: "boolean",
         category: "Global",
         default: true,
         description:
-            "See https://twig.symfony.com/doc/2.x/coding_standards.html"
+            "See https://twig.symfony.com/doc/2.x/coding_standards.html",
     },
     twigOutputEndblockName: {
         type: "boolean",
         category: "Global",
         default: false,
-        description: "Output the Twig block name in the 'endblock' tag"
-    }
+        description: "Output the Twig block name in the 'endblock' tag",
+    },
 };
 
 const pluginExports = {
     languages,
     printers,
     parsers,
-    options
+    options,
 };
 const combinedExports = Object.assign(
     {},


### PR DESCRIPTION
vim syntax highlighting plugins do set the filetype to a mix of html and twig. there is no single "twig" filetype because of how syntax highlighting works in vim.

see for example:
https://github.com/nelsyeung/twig.vim/blob/014cd47d795351f0f19f48323a3399831842d295/ftdetect/twig.vim#L2
https://github.com/sheerun/vim-polyglot/blob/c794f186c0a618d2d4cdd5445d9ff20e6f640762/autoload/polyglot/init.vim#L1917

this change allows this plugin to work with coc-prettier and vim-prettier formatting plugins.